### PR TITLE
fix: binary file handling in tree output

### DIFF
--- a/UPDATES.md
+++ b/UPDATES.md
@@ -2,6 +2,14 @@
 
 This file contains a history of important updates and changes to the AIContext tool.
 
+## Version 1.3.2 (April 2024)
+
+### Bug Fixes
+- **Fixed**: Binary file handling in directory tree output
+  - Added BINARY_EXTENSIONS check to tree generation
+  - Properly excludes binary files from tree view
+  - Improved file extension detection
+
 ## Version 1.3.0 (April 2024)
 
 ### Directory Structure Changes

--- a/lib/directoryTree.js
+++ b/lib/directoryTree.js
@@ -1,8 +1,19 @@
 import fs from 'fs';
 import path from 'path';
-import { IGNORED_DIRS } from './constants.js';
+import { IGNORED_DIRS, BINARY_EXTENSIONS } from './constants.js';
 import { minimatch } from 'minimatch';
 import { getExclusions } from './configHandler.js';
+import { getGitignorePatterns } from './gitignoreHandler.js';
+
+/**
+ * Checks if a file has a binary extension
+ * @param {string} filename - Name of the file
+ * @returns {boolean} True if file has a binary extension
+ */
+function isBinaryFile(filename) {
+    const ext = path.extname(filename).toLowerCase();
+    return BINARY_EXTENSIONS.includes(ext);
+}
 
 /**
  * Checks if a file or directory should be excluded based on patterns
@@ -39,8 +50,10 @@ export function dirTree(dir, maxDepth, currentDepth = 0, prefix = '') {
   }
 
   try {
-    // Get ignore patterns from configuration
+    // Get ignore patterns from configuration and .gitignore
     const { patterns } = getExclusions();
+    const gitignorePatterns = getGitignorePatterns();
+    const allPatterns = [...(patterns || []), ...(gitignorePatterns || [])];
 
     const items = fs.readdirSync(dir)
       .filter(item => {
@@ -48,8 +61,12 @@ export function dirTree(dir, maxDepth, currentDepth = 0, prefix = '') {
         if (item.startsWith('.') || IGNORED_DIRS.includes(item)) {
           return false;
         }
-        // Check against ignore patterns
-        if (patterns && patterns.length > 0 && shouldExclude(item, patterns)) {
+        // Skip binary files
+        if (!fs.statSync(path.join(dir, item)).isDirectory() && isBinaryFile(item)) {
+          return false;
+        }
+        // Check against all ignore patterns (including .gitignore)
+        if (allPatterns.length > 0 && shouldExclude(item, allPatterns)) {
           return false;
         }
         return true;

--- a/lib/gitignoreHandler.js
+++ b/lib/gitignoreHandler.js
@@ -2,6 +2,28 @@ import fs from 'fs';
 import path from 'path';
 import readline from 'readline';
 
+/**
+ * Get patterns from .gitignore file
+ * @returns {string[]} Array of gitignore patterns
+ */
+export function getGitignorePatterns() {
+  const gitignorePath = path.join(process.cwd(), '.gitignore');
+  
+  try {
+    if (fs.existsSync(gitignorePath)) {
+      const content = fs.readFileSync(gitignorePath, 'utf8');
+      return content
+        .split('\n')
+        .map(line => line.trim())
+        .filter(line => line && !line.startsWith('#')); // Remove empty lines and comments
+    }
+  } catch (error) {
+    console.warn('Failed to read .gitignore:', error.message);
+  }
+  
+  return [];
+}
+
 export async function checkGitIgnore() {
   const gitignorePath = path.join(process.cwd(), '.gitignore');
   const contextPattern = '.aicontext/';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aicontextjs",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "CLI tool to generate code context files",
   "main": "bin/cx.js",
   "type": "module",


### PR DESCRIPTION
- Added BINARY_EXTENSIONS check to tree generation
- Properly excludes binary files from tree view
- Improved file extension detection