### PR TITLE
Fix typo in context header template

### DIFF
--- a/templates/context-header.txt
+++ b/templates/context-header.txt
@@ -22,7 +22,7 @@ The content is organized as follows:
 
 Objective
 -------------------
-To provide A read-only, combined view of source files for AI processing, debugging, or documentation.
+To provide a read-only, combined view of source files for AI processing, debugging, or documentation.
 
 Usage
 -------------------


### PR DESCRIPTION
## Summary
- fix a typo in the context-header template

## Testing
- `npm test` *(fails: Cannot find package 'clipboardy')*