### PR TITLE
Fix truncated logs in gitignore handler

### DIFF
--- a/lib/gitignoreHandler.js
+++ b/lib/gitignoreHandler.js
@@ -47,7 +47,7 @@ export async function checkGitIgnore() {
     if (fs.existsSync(gitignorePath)) {
       const gitignoreContent = fs.readFileSync(gitignorePath, 'utf8');
       if (!gitignoreContent.includes(contextPattern)) {
-        console.log(`⚠️  We need to add '${contextPattern}' to your .gitignore file to prevent AI context files from being committed.`);
+        console.log(`⚠ .gitignore missing '${contextPattern}'`);
         const answer = await new Promise(resolve => {
           rl.question('Press Enter to continue (or "n" to cancel): ', resolve);
         });
@@ -60,7 +60,7 @@ export async function checkGitIgnore() {
         }
       }
     } else {
-      console.log(`⚠️  We need to create a .gitignore file with '${contextPattern}' to prevent AI context files from being committed.`);
+      console.log(`⚠ .gitignore not found`);
       const answer = await new Promise(resolve => {
         rl.question('Press Enter to continue (or "n" to cancel): ', resolve);
       });


### PR DESCRIPTION
## Summary
- improve warning messages in gitignore handler

## Testing
- `node --check lib/gitignoreHandler.js`
- `npm test` *(fails: Cannot find package 'clipboardy')*