### PR TITLE
Remove unused encoder and add debug helper

### DIFF
--- a/lib/contextGenerator.js
+++ b/lib/contextGenerator.js
@@ -13,7 +13,6 @@ import { execSync } from 'child_process';
 import { platform } from 'os';
 import { dirTree, formatTree } from './directoryTree.js';
 import { getOutputFilePath } from './pathUtils.js';
-import { encode } from 'gpt-3-encoder';
 import { configManager } from './configManager.js';
 import chalk from 'chalk';
 import { findFiles, shouldProcessFile, formatFileSize } from './fileUtils.js';

--- a/lib/exclusionManager.js
+++ b/lib/exclusionManager.js
@@ -48,6 +48,15 @@ export class ExclusionManager {
     }
   }
 
+  dumpPatterns() {
+    console.log('\nExclusion Patterns:');
+    console.log('Config patterns:', [...this.configPatterns].join(', '));
+    console.log('Gitignore patterns:', [...this.gitignorePatterns].join(', '));
+    console.log('System patterns:', [...this.systemPatterns].join(', '));
+    console.log('Negation patterns:', [...this.negationPatterns].join(', '));
+    console.log('All patterns:', [...this.patterns].join(', '));
+  }
+
   /**
    * Add patterns to the exclusion set
    * @param {string[]} patterns - Array of patterns to add

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "clipboardy": "^4.0.0",
     "columnify": "^1.6.0",
     "directory-tree": "^3.5.2",
-    "gpt-3-encoder": "^1.1.4",
     "minimatch": "^9.0.5",
     "ora": "^8.0.1",
     "yargs": "^17.7.2"


### PR DESCRIPTION
## Summary
- remove `gpt-3-encoder` import and dependency
- add `dumpPatterns()` diagnostic helper in `ExclusionManager`

## Testing
- `npm test` *(fails: Cannot find package 'clipboardy')*